### PR TITLE
Fix for Python 4

### DIFF
--- a/test_echo.py
+++ b/test_echo.py
@@ -139,7 +139,7 @@ def test_echo_attr_module_object_attr(testdir):
     result = testdir.runpytest('--echo-attr=linecache.cache.__class__')
     if sys.version_info[0] == 2:
         match = "    linecache.cache.__class__: <type 'dict'>"
-    elif sys.version_info[0] == 3:
+    else:
         match = "    linecache.cache.__class__: <class 'dict'>"
 
     result.stdout.fnmatch_lines([match])


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

```python
if sys.version_info[0] == 2:
    match = "    linecache.cache.__class__: <type 'dict'>"
elif sys.version_info[0] == 3:
    match = "    linecache.cache.__class__: <class 'dict'>"
```

When run on Python 4, it won't set a `match`.

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
$ flake8 --select YTT
```
